### PR TITLE
Fix ImGuiStyleVar_LayoutAlign sync issue

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -1925,8 +1925,7 @@ enum ImGuiStyleVar_
     ImGuiStyleVar_ScrollbarRounding,        // float     ScrollbarRounding
     ImGuiStyleVar_ScrollbarPadding,         // float     ScrollbarPadding
     ImGuiStyleVar_GrabMinSize,              // float     GrabMinSize
-    ImGuiStyleVar_GrabRounding,             // float     GrabRounding
-    ImGuiStyleVar_LayoutAlign,              // float     LayoutAlign
+    ImGuiStyleVar_GrabRounding,             // float     GrabRounding    
     ImGuiStyleVar_ImageRounding,            // float     ImageRounding
     ImGuiStyleVar_ImageBorderSize,          // float     ImageBorderSize
     ImGuiStyleVar_TabRounding,              // float     TabRounding
@@ -1946,6 +1945,7 @@ enum ImGuiStyleVar_
     ImGuiStyleVar_SeparatorTextAlign,       // ImVec2    SeparatorTextAlign
     ImGuiStyleVar_SeparatorTextPadding,     // ImVec2    SeparatorTextPadding
     ImGuiStyleVar_DockingSeparatorSize,     // float     DockingSeparatorSize
+    ImGuiStyleVar_LayoutAlign,              // float     LayoutAlign
     ImGuiStyleVar_COUNT
 };
 


### PR DESCRIPTION
Moved ImGuiStyleVar_LayoutAlign to the end of the enum to match its position in the GStyleVarsInfo array. This fixes an index mismatch that was triggering runtime assertions (eg in void ImGui::PushStyleVar(ImGuiStyleVar idx, const ImVec2& val)).



