### PR TITLE
StackLayout: don't inflate measured_size when layout has no springs

### DIFF
--- a/imgui_stacklayout.cpp
+++ b/imgui_stacklayout.cpp
@@ -539,7 +539,8 @@ static void ImGui::EndLayout(ImGuiLayoutType type)
     layout->CurrentSize = new_size;
 
     ImVec2 measured_size = new_size;
-    if ((auto_width || auto_height) && layout->Parent)
+    // Inflate to parent size only when there are springs that need the free space.
+    if ((auto_width || auto_height) && layout->Parent && HasAnyNonZeroSpring(*layout))
     {
         if (layout->Type == ImGuiLayoutType_Horizontal && auto_width && layout->Parent->CurrentSize.x > 0)
             layout->CurrentSize.x = layout->Parent->CurrentSize.x;


### PR DESCRIPTION
Hi @thedmd 

I stumbled upon a rather arcane bug which happens when using deeply nested layouts together with "BeginGroup".

This happened to me in a project where I make a heavy usage of the node editor and your horizontal/vertical layouts (thanks again).

### Repro and description

<img width="613" height="378" alt="image" src="https://github.com/user-attachments/assets/c1065990-2252-4163-a84d-5396bb1a6f9b" />

Can be reproduced with this code, which shows that a deep layout nesting is required (together with BeginGroup)

```cpp
void Gui()
{
    static float sizeH = 100.f;
    static float sizeV = 100.f;
    ImDrawList* dl = ImGui::GetWindowDrawList();
    const ImU32 col = IM_COL32(255, 200, 0, 255);

    ImGui::Text("Repro 1: outer BeginVertical -> BeginGroup -> BeginHorizontal");
    ImGui::TextWrapped("If you grow the width of the inner button, then reduce it (using the slider), the width of the group will grow, but never reduce");
    ImGui::SetNextItemWidth(200.f);
    ImGui::SliderFloat("sizeH", &sizeH, 50.f, 500.f);
    ImGui::BeginVertical("outer_v_for_h");
        ImGui::BeginGroup();
            ImGui::BeginHorizontal("h_repro");
                ImGui::Button("L");
                ImGui::Button("Bhh", ImVec2(sizeH, sizeH));
            ImGui::EndHorizontal();
        ImGui::EndGroup();
        dl->AddRect(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), col);
        ImVec2 sz1 = ImGui::GetItemRectSize();
        ImGui::Text("  EndGroup ItemRectSize = (%.1f, %.1f)", sz1.x, sz1.y);
    ImGui::EndVertical();

}
```

### Root cause

Let me be honest with you: I used an AI to help me diagnose the root cause of this issue (as it went deep inside your stack layout implementation). However, I did proof-read the fix, and tried to make sure it had no other side-effects. You might want to double-check it also. On my side did solve the issue.

In `EndLayout` (`imgui_stacklayout.cpp`):

```cpp
ImVec2 measured_size = new_size;
if ((auto_width || auto_height) && layout->Parent)   // ***This should happen only if there are springs***
{
    if (layout->Type == ImGuiLayoutType_Horizontal && auto_width && layout->Parent->CurrentSize.x > 0)
        layout->CurrentSize.x = layout->Parent->CurrentSize.x;
    else if (layout->Type == ImGuiLayoutType_Vertical && auto_height && layout->Parent->CurrentSize.y > 0)
        layout->CurrentSize.y = layout->Parent->CurrentSize.y;

    BalanceLayoutSprings(*layout);
    measured_size = layout->CurrentSize;
}

...

ItemSize(new_size);
ItemAdd(ImRect(layout->StartPos, layout->StartPos + measured_size), 0);
```

The intent of this branch is to give `BalanceLayoutSprings()` some
`free_space = CurrentSize - MinimumSize` to distribute among springs.
But the branch fires unconditionally whenever the layout has a parent,
regardless of whether any springs exist.

So, a possible fix consist in changing the test
```cpp
if ((auto_width || auto_height) && layout->Parent)
```

to 
```cpp
    if ((auto_width || auto_height) && layout->Parent && HasAnyNonZeroSpring(*layout))
```

As I wrote before, this is a rather arcane situation which happens with deeply nested layouts. 


Cheers